### PR TITLE
feat(temporal): add TLS SNI override support for private connectivity

### DIFF
--- a/temporal/connection.go
+++ b/temporal/connection.go
@@ -30,6 +30,8 @@ import (
 
 type Options func(*client.Options) error
 
+type TLSOptions func(*tls.Config) error
+
 // Create a connection to Temporal
 func newConnection(clientOptions *client.Options, options ...Options) (client.Client, error) {
 	for _, o := range options {
@@ -167,11 +169,19 @@ func WithPrometheusMetrics(listenAddress, prefix string, registry *prom.Registry
 	}
 }
 
-func WithTLS(enabled bool) Options {
+func WithTLS(enabled bool, tlsOpts ...TLSOptions) Options {
 	return func(o *client.Options) error {
 		if enabled {
+			tlsConfig := new(tls.Config)
+
+			for _, opt := range tlsOpts {
+				if err := opt(tlsConfig); err != nil {
+					return fmt.Errorf("error configuring tls options: %w", err)
+				}
+			}
+
 			connectionOpts := &client.ConnectionOptions{
-				TLS: new(tls.Config),
+				TLS: tlsConfig,
 			}
 			return WithConnectionOptions(connectionOpts)(o)
 		}
@@ -181,4 +191,15 @@ func WithTLS(enabled bool) Options {
 
 func WithZerolog(logger *zerolog.Logger) Options {
 	return WithLogger(NewZerologHandler(logger))
+}
+
+// TLS options
+func WithTLSServerName(serverName string) TLSOptions {
+	return func(c *tls.Config) error {
+		if serverName == "" {
+			return nil
+		}
+		c.ServerName = serverName
+		return nil
+	}
 }


### PR DESCRIPTION
## Summary

Adds `WithTLSServerName` as a `TLSOptions` functional option, and refactors `WithTLS` to accept variadic `TLSOptions` so that TLS configuration can be composed cleanly at the call site.

This is required when connecting to Temporal Cloud via AWS PrivateLink or GCP Private Service Connect, where the dial address (e.g. `vpce-*.amazonaws.com`) does not match the certificate CN (`*.tmprl.cloud`). Setting `ServerName` on the `tls.Config` overrides the SNI header sent during the TLS handshake and the hostname used for certificate verification.

## Changes

- Introduce `TLSOptions` type (`func(*tls.Config) error`) for composable TLS configuration
- Refactor `WithTLS(enabled bool)` to `WithTLS(enabled bool, tlsOpts ...TLSOptions)` — fully backwards compatible, existing callers require no changes
- Add `WithTLSServerName(serverName string) TLSOptions`

## Usage

```go
temporal.NewConnection(
    temporal.WithHostPort("vpce-xxxx.us-east-1.vpce.amazonaws.com:7233"),
    temporal.WithNamespace("my-namespace.accountId"),
    temporal.WithMTLS(certPath, certKey),
    temporal.WithTLS(true, temporal.WithTLSServerName("my-namespace.account.tmprl.cloud")),
    temporal.WithZerolog(logger),
    temporal.WithPrometheusMetrics(listenAddr, prefix, registry),
)
```
